### PR TITLE
3 Migrate output callbacks to hooks

### DIFF
--- a/classes/local/hook_callbacks.php
+++ b/classes/local/hook_callbacks.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_examguard\local;
+
+use core\hook\output\before_standard_top_of_body_html_generation;
+use local_examguard\manager;
+
+/**
+ * Hook callbacks for local_examguard.
+ * @package    local_examguard
+ * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
+ */
+class hook_callbacks {
+    /**
+     * Function to add notification to the top of the page if the exam is in
+     * progress.
+     *
+     * @param before_standard_top_of_body_html_generation $hook
+     * @return void
+     */
+    public static function before_standard_top_of_body_html_generation(before_standard_top_of_body_html_generation $hook): void {
+        global $PAGE, $USER;
+
+        // Check if the current page is a course view page or a module view page.
+        if ((str_contains($PAGE->pagetype, 'course-view') || preg_match('/mod-(.+?)-view/', $PAGE->pagetype))
+            && $PAGE->course->id != SITEID) {
+            try {
+                // Exam guard is enabled.
+                if (get_config('local_examguard', 'enabled')) {
+
+                    // Do nothing if the current user is not an editing role, e.g. student.
+                    if (!manager::user_has_an_editing_role($PAGE->course->id, $USER->id)) {
+                        return;
+                    }
+
+                    // Ban course editing if the exam is in progress / release course editing if the exam is finished.
+                    list($editingbanned, $activeexamactivities) = manager::check_course_exam_status($PAGE->course->id);
+
+                    // Add notification if course editing is banned.
+                    if ($editingbanned) {
+                        manager::show_notfication_banner($activeexamactivities);
+                    }
+                }
+            } catch (Exception $e) {
+                notification::add($e->getMessage(), notification::ERROR);
+            }
+        }
+
+        return;
+    }
+}

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 use local_examguard\manager;
 
 /**

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hooks for local_examguard.
+ *
+ * @package    local_examguard
+ * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
+ */
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
+        'callback' => \local_examguard\local\hook_callbacks::class . '::before_standard_top_of_body_html_generation',
+    ],
+];

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -22,6 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
  */
+
+defined('MOODLE_INTERNAL') || die();
+
 $callbacks = [
     [
         'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,

--- a/lib.php
+++ b/lib.php
@@ -27,42 +27,6 @@ use local_examguard\manager;
  */
 
 /**
- * Function to add notification to the top of the page if the exam is in progress.
- *
- * @return string
- */
-function local_examguard_before_standard_top_of_body_html(): string {
-    global $PAGE, $USER;
-
-    // Check if the current page is a course view page or a module view page.
-    if ((str_contains($PAGE->pagetype, 'course-view') || preg_match('/mod-(.+?)-view/', $PAGE->pagetype))
-        && $PAGE->course->id != SITEID) {
-        try {
-            // Exam guard is enabled.
-            if (get_config('local_examguard', 'enabled')) {
-
-                // Do nothing if the current user is not an editing role, e.g. student.
-                if (!manager::user_has_an_editing_role($PAGE->course->id, $USER->id)) {
-                    return '';
-                }
-
-                // Ban course editing if the exam is in progress / release course editing if the exam is finished.
-                list($editingbanned, $activeexamactivities) = manager::check_course_exam_status($PAGE->course->id);
-
-                // Add notification if course editing is banned.
-                if ($editingbanned) {
-                    manager::show_notfication_banner($activeexamactivities);
-                }
-            }
-        } catch (Exception $e) {
-            notification::add($e->getMessage(), notification::ERROR);
-        }
-    }
-
-    return '';
-}
-
-/**
  * Validate the data in the new field when the form is submitted
  *
  * @param moodleform_mod $fromform

--- a/version.php
+++ b/version.php
@@ -28,5 +28,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'local_examguard';
 $plugin->release = '0.1.1';
 $plugin->version = 2024070400;
-$plugin->requires = 2024042200; // Moodle 4.4
+$plugin->requires = 2024042200; // Moodle 4.4.
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_examguard';
-$plugin->release = '0.1.0';
-$plugin->version = 2024041000;
-$plugin->requires = 2023100900;
+$plugin->release = '0.1.1';
+$plugin->version = 2024070400;
+$plugin->requires = 2024042200; // Moodle 4.4
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
Migrate before_standard_top_of_body_html() to a hook for Moodle 4.4 (see MDL-81144).

Proposed fix for issue #3 . For this the plugin would require Moodle 4.4 or later.